### PR TITLE
run _log_history after ${PROMPT_COMMAND}

### DIFF
--- a/history.sh
+++ b/history.sh
@@ -34,7 +34,7 @@ fi
 #set up history logging of commands
 export HISTTIMEFORMAT='	%F %T	'
 export HISTCONTROL='ignorespace'
-PROMPT_COMMAND="_log_history; ${PROMPT_COMMAND}"
+PROMPT_COMMAND="${PROMPT_COMMAND}; _log_history"
 _HISTNUM=""
 _LAST_COMMAND=""
 declare -a _PWD


### PR DESCRIPTION
My  ${PROMPT_COMMAND} will display the last command's exit code. Running _log_history first will mask the previous command's exit status code. The fix is to run existing ${PROMPT_COMMAND} first.
