### PR TITLE
Avoid syntax error in case PROMPT_COMMAND is not set

### DIFF
--- a/history.sh
+++ b/history.sh
@@ -46,7 +46,11 @@ fi
 #set up history logging of commands
 export HISTTIMEFORMAT='	%F %T	'
 export HISTCONTROL='ignorespace'
-PROMPT_COMMAND="_log_history;${PROMPT_COMMAND}"
+if [ -v PROMPT_COMMAND ]; then
+  PROMPT_COMMAND="${PROMPT_COMMAND}; _log_history"
+else
+  PROMPT_COMMAND="_log_history"
+fi
 _HISTNUM=""
 _LAST_COMMAND=""
 declare -a _PWD


### PR DESCRIPTION
I got a
  -bash: PROMPT_COMMAND: line 1: syntax error near unexpected token `;'
so added a check if PROMPT_COMMAND is set.